### PR TITLE
Implemented time out report to log cluster status and condition infor…

### DIFF
--- a/extensions/reports/timeout_report.go
+++ b/extensions/reports/timeout_report.go
@@ -1,0 +1,22 @@
+package reports
+
+import (
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	steveV1 "github.com/rancher/shepherd/clients/rancher/v1"
+	"github.com/rancher/shepherd/pkg/wait"
+	"github.com/sirupsen/logrus"
+)
+
+// TimeoutRKEReport is a function that print the State and Conditions of a RKE cluster if the error is a timeout error
+func TimeoutRKEReport(cluster *management.Cluster, err error) {
+	if err != nil && cluster != nil && err.Error() == wait.TimeoutError {
+		logrus.Errorf("Timeout report State: %s, Conditions %v", cluster.State, cluster.Conditions)
+	}
+}
+
+// TimeoutClusterReport is a function that print the State of a RKE2 or K3S cluster if the error is a timeout error
+func TimeoutClusterReport(cluster *steveV1.SteveAPIObject, err error) {
+	if err != nil && cluster != nil && err.Error() == wait.TimeoutError {
+		logrus.Errorf("Timeout report State: %v", cluster.State)
+	}
+}

--- a/pkg/wait/watch.go
+++ b/pkg/wait/watch.go
@@ -6,6 +6,11 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 )
 
+var (
+	TimeoutError         = "timeout waiting on condition"
+	WatchConnectionError = "error with watch connection"
+)
+
 // WatchCheckFunc is the function type of `check` needed for WatchWait e.g.
 //
 //	 checkFunc := func(event watch.Event) (ready bool, err error) {
@@ -33,10 +38,10 @@ func WatchWait(watchInterface watch.Interface, check WatchCheckFunc) error {
 		select {
 		case event, open := <-watchInterface.ResultChan():
 			if !open {
-				return fmt.Errorf("timeout waiting on condition")
+				return fmt.Errorf(TimeoutError)
 			}
 			if event.Type == watch.Error {
-				return fmt.Errorf("error with watch connection")
+				return fmt.Errorf(WatchConnectionError)
 			}
 
 			done, err := check(event)


### PR DESCRIPTION
…mation to the provisioning tests

- Implemented TimeoutReport function
- Refactor watch function to use TimeoutError and WatchConnectionError variables

Implemented time out report to log cluster status and condition information to the provisioning tests

- Implemented TimeoutRKEReport function
- Implemented TimeoutClusterReport function
- Refactor watch function to use TimeoutError and WatchConnectionError variables
- Change VerifyRKE1Cluster to use TimeoutRKEReport function
- Change VerifyCluster to use TimeoutClusterReport function
- Change VerifyHostedCluster to use TimeoutRKEReport function